### PR TITLE
Removed default assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -3,7 +3,6 @@ name: Bug report template for PlayStation Home Online
 about: Create a report to help us improve our custom PlayStation Home servers.
 title: ''
 labels: Bug
-assignees: NagatoDEV, Toykyle
 
 ---
 


### PR DESCRIPTION
Most issues are 3rd party API emulation-related; having Nagato and Kyle assigned by default will make them receive lots of unnecessary pings.